### PR TITLE
leave guilds that the bot shouldn't be in

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -3,6 +3,7 @@ bot:
   token: 'TOKEN'
   prefix: '!'
   owners: ['Owner ID 1', 'Owner ID 2']
+  guildWhitelist: ['Guild ID 1', 'Guild ID 2']
 server:
   domain: ''
   appkey: 'put some random stuff here'

--- a/src/bot/events.ts
+++ b/src/bot/events.ts
@@ -1,6 +1,7 @@
 import { Mutex, MutexInterface } from 'async-mutex';
 import {
   DMChannel,
+  Guild,
   GuildMember,
   Message,
   PartialGuildMember,
@@ -26,6 +27,13 @@ export default class EventHandler {
    * @param {Message} msg
    */
   public async onMessage(msg: Message): Promise<void> {
+    if (msg.channel.type === 'text') {
+      const { guildWhitelist } = CONFIG.bot;
+      if (guildWhitelist.length > 0 && !guildWhitelist.includes(msg.channel.guild.id)) {
+        await msg.channel.guild.leave();
+        return;
+      }
+    }
     const msgCtrl = this.modmail.messages;
     if (!msg.author.bot && !msg.content.startsWith(CONFIG.bot.prefix)) {
       if (msg.channel.type === 'dm') {
@@ -48,6 +56,18 @@ export default class EventHandler {
   public async onReady(): Promise<void> {
     const log = EventHandler.getLogger();
     log.info('Bot is ready.');
+    const { guildWhitelist } = CONFIG.bot;
+    if (guildWhitelist.length > 0) {
+      const leaveList = [];
+      // this returns an iterable. This is the intended syntax for it.
+      // eslint-disable-next-line no-restricted-syntax
+      for (const guild of this.modmail.guilds.cache.values()) {
+        if (!guildWhitelist.includes(guild.id)) {
+          leaveList.push(guild.leave());
+        }
+      }
+      await Promise.all(leaveList);
+    }
   }
 
   /**
@@ -224,5 +244,12 @@ export default class EventHandler {
 
   private static getLogger() {
     return ModmailBot.getLogger('events');
+  }
+
+  public async onGuildCreate(guild: Guild): Promise<void> {
+    const { guildWhitelist } = CONFIG.bot;
+    if (guildWhitelist.length > 0 && !guildWhitelist.includes(guild.id)) {
+      await guild.leave();
+    }
   }
 }

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -123,6 +123,8 @@ export default class ModmailBot extends CommandoClient {
       .on('guildMemberRemove', this.events.onMemberLeave.bind(this.events))
       .on('guildMemberUpdate', this.events.onMemberUpdate.bind(this.events));
 
+    this.on('guildCreate', this.events.onGuildCreate.bind(this.events));
+
     this.once('ready', this.events.onReady.bind(this.events));
 
     if (parentPort) {

--- a/src/config/bot.ts
+++ b/src/config/bot.ts
@@ -7,10 +7,13 @@ export default class BotConfig extends Conf {
 
   public readonly owners: string[];
 
+  public readonly guildWhitelist: string[];
+
   constructor() {
     super('bot');
     this.token = '';
     this.prefix = '!';
     this.owners = ['Owner ID 1', 'Owner ID 2'];
+    this.guildWhitelist = [];
   }
 }


### PR DESCRIPTION
This pull request adds functionality for it to leave a guild if it is not in a whitelist.
for backwards compatability, it will only perfom this operation if the configured list is not empty.

The reason for this feature is for the situation where the bot was accidentally left set to public when it was created.